### PR TITLE
Put build architecture into Info.plist on mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
         os:
           - windows-latest
           - macos-latest
+          - macos-15-intel
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ linux: dir
 mac: prerequisites
 	mkdir -p $(APPNAME).app/Contents
 	cp -rf platform/mac/* assets $(NAME).exe $(APPNAME).app/Contents
+	/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority array" $(APPNAME).app/Contents/Info.plist
+	/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority:0 string $(shell uname -m)" $(APPNAME).app/Contents/Info.plist
 	chmod +x $(APPNAME).app/Contents/MacOS/run.sh
 
 mac-debug: mac


### PR DESCRIPTION
I have an Apple Silicon mac, but I do not have Rosetta installed, and need to avoid doing so for work reasons.

By default, macOS alerts me I need Rosetta with camp, which I understand to be because the executable identified in the bundle is a shell script, and macOS can not detect the platform type for that, so assumes x86.

This PR adds an extra key to the bundle, [LSArchitecturePriority](https://developer.apple.com/documentation/BundleResources/Information-Property-List/LSArchitecturePriority), at build time to insert the platform of the build architecture, on the assumption that therse match - it doesn't look. to me that the Makefile would build a fat binary and inspecting camp.exe it seems to be just built for the host platform type.

Unfortunately I do not have access to an Intel mac to verify this works for the other platform, however I asked on the fediverse what `uname -m` returns on Intel macs and I can cofirm that it matches what is specified on that documentation for LSArchitecturePriority. So in theory, we should be good, but I can't confirm that in practice. I can just say it works now on my Apple Silicon mac sans Rosetta!